### PR TITLE
Change logging and fix pydantic warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sirena-client"
-version = "0.1.11-alpha"
+version = "0.1.12-alpha"
 description = "SirenaGDS Python Client"
 authors = ["Utair"]
 packages = [

--- a/utair/clients/external/sirena/base/client/base_client.py
+++ b/utair/clients/external/sirena/base/client/base_client.py
@@ -154,6 +154,8 @@ class BaseClient(ABC):
 
     def _request_log(self, request: RequestModelABC, response: ResponseModelABC):
         self.logger.info(f"Sirena request: {request.method_name}", extra=dict(
-            sirena_request=json.dumps(request.build(), indent=4),
-            sirena_response=json.dumps(response.payload or {}, indent=4),
+            integrator_name="sirena",
+            api_method=request.method_name,
+            request_body=json.dumps(request.build(), indent=4),
+            response_body=json.dumps(response.payload or {}, indent=4),
         ))

--- a/utair/clients/external/sirena/base/models/base_client_request.py
+++ b/utair/clients/external/sirena/base/models/base_client_request.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from abc import ABC, abstractmethod
-from pydantic import BaseModel, validator, Field
+from pydantic import BaseModel, field_validator, Field
 from xmltodict import unparse
 from utair.clients.external.sirena.base.types import AsymEncryptionHandShake, PublicMethods
 
@@ -9,7 +9,7 @@ class RequestModelABC(BaseModel, ABC):
     _method_name: str = ''
     _nested: bool = False   # Вложенная часть
 
-    @validator("rloc", pre=False, check_fields=False)
+    @field_validator("rloc")
     def format_rloc(cls, rloc: Optional[str]) -> Optional[str]:
         """
         Форматирование рлока
@@ -18,7 +18,7 @@ class RequestModelABC(BaseModel, ABC):
             return rloc.split('/')[0]
         return rloc
 
-    @validator("last_name", pre=False, check_fields=False)
+    @field_validator("last_name")
     def format_last_name(cls, last_name: Optional[str]) -> Optional[str]:
         """
         Форматирование фамилии


### PR DESCRIPTION
- Расширено логирование методов

- Исправлено: `PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0`