### PR TITLE
Pricing route refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 _sandbox
 sirena.pem⏎
 poetry.lock
+.cursor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sirena-client"
-version = "0.1.19-alpha"
+version = "0.1.20-alpha"
 description = "SirenaGDS Python Client"
 authors = ["Utair"]
 packages = [

--- a/utair/clients/external/sirena/requests/common.py
+++ b/utair/clients/external/sirena/requests/common.py
@@ -133,6 +133,7 @@ class ExchangeSegments(RequestModelABC):
 
         return request
 
+
 class Passenger(RequestModelABC):
     """
     Информация о пассажире, используется в GetCalendar, GetPricingRoute
@@ -163,111 +164,8 @@ class Passenger(RequestModelABC):
         return request
 
 
-class RequestParams(RequestModelABC):
-    """
-    Параметры запроса, используется в GetPricingRoute, GetPricingMonoBrand
-    """
-    min_results: Optional[int] = Field(description="Минимальное желаемое количество разных оценок", default=None)
-    max_results: Optional[int] = Field(description="Максимальное количество вариантов, возвращаемых в ответе",
-                                       default=None)
-    timeout: Optional[int] = Field(description="Таймаут выполнения запроса (секунды)", default=None)
-    mix_scls: Optional[bool] = Field(description="Комбинировать подклассы на сегментах по маршруту перевозки",
-                                     default=None)
-    mix_ac: Optional[bool] = Field(description="Комбинировать рейсы разных перевозчиков по маршруту перевозки",
-                                   default=None)
-    comb_rules: Optional[str] = Field(description="Правила комбинирования рейсов авиакомпаний", default=None)
-    fingering_order: Optional[str] = Field(description="Порядок перебора вариантов при оценке", default=None)
-    price_child_aaa: Optional[bool] = Field(description="Провести тарификацию ребёнка по взрослому тарифу, если не "
-                                                        "найдено скидок", default=None)
-    asynchronous_fares: Optional[bool] = Field(description="Не применять тарифы с одновременным бронированием и "
-                                                           "оформлением", default=None)
-    show_tmb: Optional[bool] = Field(description="Готовить и показывать справку по норме провоза багажа",
-                                     default=None)
-    formpay: Optional[str] = Field(description="Форма оплаты для оценки", default=None)
-    pt_baggage: Optional[bool] = Field(description="Показывать только 'багажные' тарифы", default=None)
-    # todo
-    et_if_possible: Optional[bool] = Field(description="", default=False)
-    allow_change_of_airport: Optional[bool] = Field(description="Разрешены ли пересадки со сменой аэропорта",
-                                                    default=False)
-    real_seats: Optional[bool] = Field(description="Учитывать реальное количество оставшихся мест в подклассе",
-                                       default=None)
-
-    def build(self) -> dict:
-        request ={
-            "min_results": self.min_results,
-            "max_results": self.max_results,
-            "timeout": self.timeout,
-            "mix_scls": self.mix_scls,
-            "mix_ac": self.mix_ac,
-            "comb_rules": self.comb_rules,
-            "fingering_order": self.fingering_order,
-            "price_child_aaa": self.price_child_aaa,
-            "asynchronous_fares": self.asynchronous_fares,
-            "show_tmb": self.show_tmb,
-            "formpay": self.formpay,
-            "pt_baggage": self.pt_baggage,
-            "allow_change_of_airport": self.allow_change_of_airport,
-            "et_if_possible": self.et_if_possible
-            # et_if_possible, n_prices
-        }
-        if self.real_seats:
-            request['real_seats'] = self.real_seats
-        return request
-
-
-class AnswerParams(RequestModelABC):
-    """
-    Параметры ответа, используется в GetPricingRoute, GetPricingMonoBrand
-    """
-    show_available: Optional[bool] = Field(description="Добавлять в ответ информацию о наличии мест на подклассе",
-                                           default=None)
-    show_io_matching: Optional[bool] = Field(description="Добавлять в ответ информацию о соответствии сегментов "
-                                                         "запроса сегментам ответа", default=None)
-    show_flighttime: Optional[bool] = Field(description="Добавлять в ответ информацию о времени перелета и времени "
-                                                        "следования по сегментам", default=None)
-    show_varianttotal: Optional[bool] = Field(description="Добавлять в ответ информацию об общей стоимости перевозки "
-                                                          "по варианту", default=None)
-    show_baseclass: Optional[bool] = Field(description="Добавлять к каждому подклассу код его базового класса",
-                                           default=None)
-    show_reg_latin: Optional[bool] = Field(description="Указывать необходимость оформления билета на латинице",
-                                           default=None)
-    show_upt_rec: Optional[bool] = Field(description="Выдать детализацию УПТ", default=None)
-    show_fareexpdate: Optional[bool] = Field(description="Указывать дату истечения срока действия тарифа", default=None)
-    show_n_blanks: Optional[bool] = Field(description="Возвращать количество билетов, необходимых для оформления "
-                                                      "перевозки", default=None)
-    regroup: Optional[bool] = Field(description="Перегруппировка ответа", default=None)
-    split_companies: Optional[bool] = Field(description="При перегруппировке ответа объединять в один вариант только "
-                                                        "рейсы одной авиакомпании. Автоматически установит параметр "
-                                                        "запроса mix_ac='false'", default=None)
-    reference_style_codes: Optional[bool] = Field(description="Возвращать коды авиакомпаний по правилам, принятым в "
-                                                              "справочных запросах (может вернуть латинский код а/к "
-                                                              "вместо русского)", default=None)
-    mark_cityport: Optional[bool] = Field(description="Добавлять в ответ признаки city или airport для пунктов",
-                                          default=None)
-    show_tml: Optional[bool] = Field(description="Добавлять в ответ информацию о ТЛ на оформление перевозки",
-                                     default=None)
-    show_brand_info: Optional[bool] = Field(description="Добавлять в ответ информацию о составе брендов", default=None)
-    show_cat18: Optional[bool] = Field(description="Добавлять в ответ примечания из кат. 18 УПТ", default=None)
-    lang: str = 'en'
-
-    def build(self) -> dict:
-        return {
-            "lang": self.lang,
-            "show_available": self.show_available,
-            "show_io_matching": self.show_io_matching,
-            "show_flighttime": self.show_flighttime,
-            "show_varianttotal": self.show_varianttotal,
-            "show_baseclass": self.show_baseclass,
-            "show_reg_latin": self.show_reg_latin,
-            "show_upt_rec": self.show_upt_rec,
-            "show_fareexpdate": self.show_fareexpdate,
-            "show_n_blanks": self.show_n_blanks,
-            "regroup": self.regroup,
-            "split_companies": self.split_companies,
-            "reference_style_codes": self.reference_style_codes,
-            "mark_cityport": self.mark_cityport,
-            "show_tml": self.show_tml,
-            "show_brand_info": self.show_brand_info,
-            "show_cat18": self.show_cat18,
-            # "return_date", "show_et", "show_regroup_io_matching", "show_trcantpr", "joint_type"
-        }
+# Re-export: публичный API RequestParams / AnswerParams остаётся в common. Реализация в pricing_common.
+from utair.clients.external.sirena.requests.pricing_common import (  # noqa: E402
+    PricingAnswerParams as AnswerParams,
+    PricingRequestParams as RequestParams,
+)

--- a/utair/clients/external/sirena/requests/get_pricing_route.py
+++ b/utair/clients/external/sirena/requests/get_pricing_route.py
@@ -1,39 +1,122 @@
 from datetime import date
-from typing import Optional, List
-from pydantic import Field
-from utair.clients.external.sirena.requests.common import Passenger, RequestParams, AnswerParams
+from typing import List, Literal, Optional, Union
+
+from pydantic import Field, model_validator
+
 from utair.clients.external.sirena.base.models.base_client_request import RequestModelABC
+from utair.clients.external.sirena.requests.add_ssr_to_order import SSRForAdd
+from utair.clients.external.sirena.requests.pricing_common import (
+    PricingAcomp,
+    PricingAnswerParams,
+    PricingFlightFilter,
+    PricingRequestParams,
+)
+
+__all__ = [
+    "GetPricingRoute",
+    "PricingRouteSegment",
+    "PricingRoutePassenger",
+    "PricingAcomp",
+    "PricingFlightFilter",
+    "PricingRequestParams",
+    "PricingAnswerParams",
+]
 
 
 class PricingRouteSegment(RequestModelABC):
+    """
+    Сегмент маршрута для запроса pricing_route
+    """
+
     departure: str = Field(description="Код города или порта отправления")
     arrival: str = Field(description="Код города или порта прибытия")
     # по дэфолту название date, поэтому переименовал
     departure_date: date = Field(description="Дата вылета")
-    company: Optional[str] = Field(description="Код маркетингового перевозчика",
-                                   default=None)
-    flight: Optional[str] = Field(description="Маркетинговый номер рейса",
-                                  default=None)
-    subclass: Optional[str] = Field(description="Класс бронирования",
-                                    default=None)
+
+    company: Optional[Union[str, List[str]]] = Field(
+        description="Код(ы) маркетингового перевозчика",
+        default=None,
+    )
+    flight: Optional[str] = Field(
+        description="Маркетинговый номер рейса",
+        default=None,
+    )
+    subclass: Optional[Union[str, List[str]]] = Field(
+        description="Класс(ы) бронирования",
+        default=None,
+    )
     # по дэфолту название class, поэтому переименовал
-    service_class: Optional[str] = Field(description="Класс обслуживания",
-                                         default=None)
-    direct: Optional[bool] = Field(description="Признак вывода только прямых рейсов",
-                                   default=True)
-    connections: Optional[str] = Field(description="Правило отображения стыковочных рейсов",
-                                       default=None)
-    time_from: Optional[int] = Field(description="Самое раннее время вылета (включительно)",
-                                     default=0)
-    time_till: Optional[int] = Field(description="Самое позднее время вылета (не включительно)",
-                                     default=2400)
-    desire: Optional[str] = Field(description="Список рейсов, которые будут рассматриваться при оценке",
-                                  default=None)
-    ignore: Optional[str] = Field(description="Список рейсов, исключаемых из рассмотрения",
-                                  default=None)
+    service_class: Optional[Union[str, List[str]]] = Field(
+        description="Класс(ы) обслуживания (Э/Y, Б/C, П/F)",
+        default=None,
+    )
+    cabin: Optional[Union[str, List[str]]] = Field(
+        description="Кабина(ы) (PFJCWY)",
+        default=None,
+    )
+
+    direct: Optional[bool] = Field(
+        description="Признак вывода только прямых рейсов",
+        default=True,
+    )
+    connections: Optional[str] = Field(
+        description="Правило отображения стыковочных рейсов ('only' или код пункта стыковки)",
+        default=None,
+    )
+    time_from: Optional[int] = Field(
+        description="Самое раннее время вылета (включительно)",
+        default=0,
+    )
+    time_till: Optional[int] = Field(
+        description="Самое позднее время вылета (не включительно)",
+        default=2400,
+    )
+
+    desire: Optional[PricingFlightFilter] = Field(
+        description="Список рейсов, которые будут рассматриваться при оценке",
+        default=None,
+    )
+    ignore: Optional[PricingFlightFilter] = Field(
+        description="Список рейсов, исключаемых из рассмотрения",
+        default=None,
+    )
+
+    segment_id: Optional[int] = Field(
+        description="Идентификатор сегмента (атрибут @id). Учитываются только значения > 0.",
+        default=None,
+    )
+    joint_id: Optional[int] = Field(
+        description="Идентификатор сегмента стыковочного рейса (атрибут @joint_id). "
+        "Учитываются только значения > 0.",
+        default=None,
+    )
+    marriage_id: Optional[int] = Field(
+        description="Идентификатор марьяжного сегмента (атрибут @marriage_id). "
+        "Учитываются только значения > 0. Нельзя одновременно с joint_id.",
+        default=None,
+    )
+
+    _nested: bool = True
+
+    @model_validator(mode="after")
+    def _check_connections_and_marriage(self) -> "PricingRouteSegment":
+        if self.connections and self.direct:
+            raise ValueError(
+                "Параметр 'connections' допускается передавать только совместно с direct=False"
+            )
+        if (
+            self.joint_id is not None
+            and self.joint_id > 0
+            and self.marriage_id is not None
+            and self.marriage_id > 0
+        ):
+            raise ValueError(
+                "Нельзя одновременно указывать ненулевые значения 'marriage_id' и 'joint_id'"
+            )
+        return self
 
     def build(self) -> dict:
-        return {
+        request: dict = {
             "departure": self.departure,
             "arrival": self.arrival,
             "date": self.departure_date.strftime("%d.%m.%y"),
@@ -41,35 +124,130 @@ class PricingRouteSegment(RequestModelABC):
             "flight": self.flight,
             "subclass": self.subclass,
             "class": self.service_class,
+            "cabin": self.cabin,
             "direct": self.direct,
             "connections": self.connections,
             "time_from": self.time_from,
             "time_till": self.time_till,
-            "desire": self.desire,
-            "ignore": self.ignore,
+            "desire": self.desire.build() if self.desire else None,
+            "ignore": self.ignore.build() if self.ignore else None,
         }
+        if self.segment_id is not None and self.segment_id > 0:
+            request["@id"] = self.segment_id
+        if self.joint_id is not None and self.joint_id > 0:
+            request["@joint_id"] = self.joint_id
+        if self.marriage_id is not None and self.marriage_id > 0:
+            request["@marriage_id"] = self.marriage_id
+        return request
+
+
+class PricingRoutePassenger(RequestModelABC):
+    """
+    Информация о пассажире для запроса pricing_route
+    Атрибут @id не описан в таблице, но используется в примерах и в orig_id ответа.
+    """
+
+    code: str = Field(description="Код категории пассажира")
+    age: Optional[int] = Field(
+        description="Возраст пассажира (кол-во полных лет)",
+        default=None,
+    )
+    sex: Optional[Literal["male", "female"]] = Field(
+        description="Пол пассажира",
+        default=None,
+    )
+    doc: Optional[str] = Field(description="Основной документ", default=None)
+    doc2: Optional[str] = Field(description="Документ на льготу", default=None)
+    citizenship: Optional[str] = Field(description="Гражданство", default=None)
+    residence: Optional[str] = Field(description="Страна/город/округ/регион проживания", default=None)
+    count: Optional[int] = Field(
+        description="Количество пассажиров с такими параметрами",
+        default=1,
+    )
+    n_seats: Optional[int] = Field(
+        description="Количество мест, занимаемых пассажиром (для EXST)",
+        default=None,
+    )
+    passenger_id: Optional[int] = Field(
+        description="Идентификатор пассажира (атрибут @id), для связи с SSR pass_id",
+        default=None,
+    )
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        request: dict = {
+            "code": self.code,
+            "age": self.age,
+            "sex": self.sex,
+            "doc": self.doc,
+            "doc2": self.doc2,
+            "citizenship": self.citizenship,
+            "residence": self.residence,
+            "count": self.count,
+            "n_seats": self.n_seats,
+        }
+        if self.passenger_id is not None and self.passenger_id > 0:
+            request["@id"] = self.passenger_id
+        return request
 
 
 class GetPricingRoute(RequestModelABC):
-    segments: List[PricingRouteSegment] = Field(description="Сегмент маршрута")
-    passengers: List[Passenger] = Field(description="Данные пассажира(-ов)")
-    special_services: Optional[dict] = Field(description="Данные SSR",
-                                             default={})
-    request_params: Optional[RequestParams] = Field(description="Дополнительные параметры запроса",
-                                                    default=None)
-    answer_params: Optional[AnswerParams] = Field(description="Дополнительные параметры ответа",
-                                                  default=None)
+    """
+    Поиск вариантов перевозки и оценка их стоимости (pricing_route)
+    """
 
-    lang: str = 'en'
+    segments: List[PricingRouteSegment] = Field(description="Сегменты маршрута")
+    passengers: List[PricingRoutePassenger] = Field(description="Данные пассажира(-ов)")
+    special_services: Optional[List[SSRForAdd]] = Field(
+        description="SSR, добавляемые в запрос (специальные тарифы, accounting code, FQTV и т.п.)",
+        default=None,
+    )
+    request_params: Optional[PricingRequestParams] = Field(
+        description="Дополнительные параметры запроса",
+        default=None,
+    )
+    answer_params: Optional[PricingAnswerParams] = Field(
+        description="Дополнительные параметры ответа",
+        default=None,
+    )
 
-    _method_name: str = 'pricing_route'
+    _method_name: str = "pricing_route"
+
+    @model_validator(mode="after")
+    def _check_limits(self) -> "GetPricingRoute":
+        """
+        Из документации Sirena:
+        - Без указания номеров рейсов возможно передавать данные не более 4 сегментов;
+        - При указании на каждом сегменте номеров рейсов возможно передавать данные не более 4 стыковочных рейсов;
+        - Общее количество пассажиров не должно превышать девяти.
+        """
+        if self.segments:
+            has_flight = [bool(s.flight) for s in self.segments]
+            if not any(has_flight) and len(self.segments) > 4:
+                raise ValueError(
+                    "Без указания номеров рейсов возможно передавать не более 4 сегментов"
+                )
+            if all(has_flight) and len(self.segments) > 4:
+                raise ValueError(
+                    "При указании на каждом сегменте номеров рейсов возможно передавать "
+                    "не более 4 стыковочных рейсов"
+                )
+
+        total_pax = sum((p.count or 1) for p in self.passengers)
+        if total_pax > 9:
+            raise ValueError("Общее количество пассажиров не должно превышать девяти")
+        return self
 
     def build(self) -> dict:
-        request = {
+        request: dict = {
             "segment": [s.build() for s in self.segments],
             "passenger": [p.build() for p in self.passengers],
-            "special_services": self.special_services,
             "request_params": self.request_params.build() if self.request_params else {},
             "answer_params": self.answer_params.build() if self.answer_params else {},
         }
+        if self.special_services:
+            request["special_services"] = {
+                "ssrs": {"ssr": [s.build() for s in self.special_services]}
+            }
         return request

--- a/utair/clients/external/sirena/requests/get_pricing_route.py
+++ b/utair/clients/external/sirena/requests/get_pricing_route.py
@@ -11,16 +11,29 @@ from utair.clients.external.sirena.requests.pricing_common import (
     PricingFlightFilter,
     PricingRequestParams,
 )
-
 __all__ = [
     "GetPricingRoute",
     "PricingRouteSegment",
     "PricingRoutePassenger",
+    "PricingRouteBrand",
     "PricingAcomp",
     "PricingFlightFilter",
     "PricingRequestParams",
     "PricingAnswerParams",
 ]
+
+
+class PricingRouteBrand(RequestModelABC):
+    """Элемент request_params.brand. Переоценка корзины с брендом тарифа (MN, OP, …)."""
+
+    # Недокументировано в wiki (Table 2.34): request_params.brand
+    segment_id: str = Field(description="Идентификатор сегмента (@seg_id)")
+    brand_code: str = Field(description="Код бренда (#text), напр. MN, OP, MIN")
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        return {"@seg_id": self.segment_id, "#text": self.brand_code}
 
 
 class PricingRouteSegment(RequestModelABC):
@@ -168,6 +181,7 @@ class PricingRoutePassenger(RequestModelABC):
         description="Количество мест, занимаемых пассажиром (для EXST)",
         default=None,
     )
+    # Недокументировано в Table 2.33, есть в Examples (SSR pass_id)
     passenger_id: Optional[int] = Field(
         description="Идентификатор пассажира (атрибут @id), для связи с SSR pass_id",
         default=None,
@@ -211,6 +225,11 @@ class GetPricingRoute(RequestModelABC):
         description="Дополнительные параметры ответа",
         default=None,
     )
+    # Недокументировано в wiki (Table 2.34): request_params.brand
+    brands: Optional[List[PricingRouteBrand]] = Field(
+        description="Бренды тарифов по сегментам (request_params.brand)",
+        default=None,
+    )
 
     _method_name: str = "pricing_route"
 
@@ -240,10 +259,14 @@ class GetPricingRoute(RequestModelABC):
         return self
 
     def build(self) -> dict:
+        request_params = self.request_params.build() if self.request_params else {}
+        if self.brands:
+            request_params["brand"] = [b.build() for b in self.brands]
+
         request: dict = {
             "segment": [s.build() for s in self.segments],
             "passenger": [p.build() for p in self.passengers],
-            "request_params": self.request_params.build() if self.request_params else {},
+            "request_params": request_params,
             "answer_params": self.answer_params.build() if self.answer_params else {},
         }
         if self.special_services:

--- a/utair/clients/external/sirena/requests/params_base.py
+++ b/utair/clients/external/sirena/requests/params_base.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+from pydantic import Field
+
+from utair.clients.external.sirena.base.models.base_client_request import RequestModelABC
+
+
+class BaseRequestParams(RequestModelABC):
+    """
+    Общие параметры секции <request_params> (Table 1.5).
+    """
+
+    ersp_code: Optional[str] = Field(
+        description="Код интернет-пункта продажи",
+        default=None,
+    )
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        return {"ersp_code": self.ersp_code}
+
+
+class BaseAnswerParams(RequestModelABC):
+    """
+    Общие параметры секции <answer_params> (Table 1.4).
+    """
+
+    lang: Optional[str] = Field(
+        description="Язык ответа (en|ru). По умолчанию — язык виртуального пульта.",
+        default="en",
+    )
+    curr: Optional[str] = Field(
+        description="Валюта ответа (код валюты). По умолчанию — валюта виртуального пульта.",
+        default=None,
+    )
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        return {"lang": self.lang, "curr": self.curr}

--- a/utair/clients/external/sirena/requests/pricing_common.py
+++ b/utair/clients/external/sirena/requests/pricing_common.py
@@ -1,0 +1,292 @@
+from typing import List, Literal, Optional, Union
+
+from pydantic import Field
+
+from utair.clients.external.sirena.base.models.base_client_request import RequestModelABC
+from utair.clients.external.sirena.requests.params_base import BaseAnswerParams, BaseRequestParams
+
+
+class PricingAcomp(RequestModelABC):
+    name: str = Field(description="Код авиакомпании (атрибут @name)")
+    flights: Optional[List[str]] = Field(
+        description="Номера рейсов. '*' — все рейсы указанной авиакомпании.",
+        default=None,
+    )
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        request: dict = {"@name": self.name}
+        if self.flights:
+            request["flight"] = list(self.flights) if len(self.flights) > 1 else self.flights[0]
+        return request
+
+
+class PricingFlightFilter(RequestModelABC):
+    """Структура элементов <desire> и <ignore>."""
+
+    acomps: List[PricingAcomp] = Field(description="Список авиакомпаний/рейсов фильтра")
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        if not self.acomps:
+            return {}
+        items = [a.build() for a in self.acomps]
+        return {"acomp": items if len(items) > 1 else items[0]}
+
+
+class PricingCombRule(RequestModelABC):
+    comb: Literal["yes", "no"] = Field(description="Разрешить комбинирование")
+    acomps: List[str] = Field(description="Коды авиакомпаний (или '*')")
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        request: dict = {"@comb": self.comb}
+        if self.acomps:
+            request["acomp"] = list(self.acomps) if len(self.acomps) > 1 else self.acomps[0]
+        return request
+
+
+class PricingFormPay(RequestModelABC):
+    code: str = Field(description="Код формы оплаты")
+    type: Optional[str] = Field(
+        description="Тип платёжного средства/системы",
+        default=None,
+    )
+    num: Optional[str] = Field(
+        description="Номер/идентификатор платёжного средства",
+        default=None,
+    )
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        request: dict = {"#text": self.code}
+        if self.type is not None:
+            request["@type"] = self.type
+        if self.num is not None:
+            request["@num"] = self.num
+        return request
+
+
+class PricingRequestParams(BaseRequestParams):
+    """
+    Специфичные параметры <request_params> для pricing-запросов
+    """
+
+    min_results: Optional[Union[int, Literal["spOnePass"]]] = Field(
+        description="Минимальное желаемое количество разных оценок "
+        "(число или спец-значение 'spOnePass')",
+        default=None,
+    )
+    max_results: Optional[int] = Field(
+        description="Максимальное количество вариантов, возвращаемых в ответе",
+        default=None,
+    )
+    timeout: Optional[int] = Field(
+        description="Таймаут выполнения запроса (секунды, от 5 до 150)",
+        default=None,
+    )
+    mix_scls: Optional[bool] = Field(
+        description="Комбинировать подклассы на сегментах по маршруту перевозки",
+        default=None,
+    )
+    mix_ac: Optional[bool] = Field(
+        description="Комбинировать рейсы разных перевозчиков по маршруту перевозки",
+        default=None,
+    )
+    comb_rules: Optional[Union[str, List[PricingCombRule]]] = Field(
+        description="Правила комбинирования рейсов авиакомпаний",
+        default=None,
+    )
+    fingering_order: Optional[str] = Field(
+        description="Порядок перебора вариантов при оценке "
+        "(ordinary, differentFirst, differentFlightsCombFirst, differentFlightsFirst)",
+        default=None,
+    )
+    price_child_aaa: Optional[bool] = Field(
+        description="Провести тарификацию ребёнка по взрослому тарифу, если не найдено скидок",
+        default=None,
+    )
+    asynchronous_fares: Optional[bool] = Field(
+        description="Не применять тарифы с одновременным бронированием и оформлением",
+        default=None,
+    )
+    show_tmb: Optional[bool] = Field(
+        description="Готовить и показывать справку по норме провоза багажа",
+        default=None,
+    )
+    formpay: Optional[Union[str, PricingFormPay]] = Field(
+        description="Форма оплаты для оценки",
+        default=None,
+    )
+    pt_baggage: Optional[bool] = Field(
+        description="Показывать только 'багажные' тарифы",
+        default=None,
+    )
+    # далее идут недокументированные параметры:
+    et_if_possible: Optional[bool] = Field(
+        description="Оформление ЭБ при возможности",
+        default=False,
+    )
+    allow_change_of_airport: Optional[bool] = Field(
+        description="Пересадки со сменой аэропорта",
+        default=False,
+    )
+    real_seats: Optional[bool] = Field(
+        description="Учитывать реальное количество мест",
+        default=None,
+    )
+    # --------------------------------
+
+    _nested: bool = True
+
+    # реализация для обратной совместимости:
+    @staticmethod
+    def _build_comb_rules(
+        comb_rules: Optional[Union[str, List[PricingCombRule]]],
+    ) -> Optional[Union[str, dict]]:
+        if comb_rules is None:
+            return None
+        if isinstance(comb_rules, str):
+            return comb_rules
+        rules = [r.build() for r in comb_rules]
+        return {"rule": rules if len(rules) > 1 else rules[0]}
+    # --------------------------------
+
+    def build(self) -> dict:
+        # реализация для обратной совместимости:
+        formpay: Optional[Union[str, dict]]
+        if isinstance(self.formpay, PricingFormPay):
+            formpay = self.formpay.build()
+        else:
+            formpay = self.formpay
+        # --------------------------------
+        request = {
+            **super().build(),
+            "min_results": self.min_results,
+            "max_results": self.max_results,
+            "timeout": self.timeout,
+            "mix_scls": self.mix_scls,
+            "mix_ac": self.mix_ac,
+            "comb_rules": self._build_comb_rules(self.comb_rules),
+            "fingering_order": self.fingering_order,
+            "price_child_aaa": self.price_child_aaa,
+            "asynchronous_fares": self.asynchronous_fares,
+            "show_tmb": self.show_tmb,
+            "formpay": formpay,
+            "pt_baggage": self.pt_baggage,
+            "allow_change_of_airport": self.allow_change_of_airport,
+            "et_if_possible": self.et_if_possible,
+        }
+        if self.real_seats:
+            request["real_seats"] = self.real_seats
+        return request
+
+
+class PricingAnswerParams(BaseAnswerParams):
+    """
+    Специфичные параметры <answer_params> для pricing-запросов
+    """
+
+    show_available: Optional[bool] = Field(
+        description="Добавлять в ответ информацию о наличии мест на подклассе",
+        default=None,
+    )
+    show_io_matching: Optional[bool] = Field(
+        description="Добавлять в ответ информацию о соответствии сегментов запроса сегментам ответа",
+        default=None,
+    )
+    show_flighttime: Optional[bool] = Field(
+        description="Добавлять в ответ информацию о времени перелета и времени следования по сегментам",
+        default=None,
+    )
+    show_varianttotal: Optional[bool] = Field(
+        description="Добавлять в ответ информацию об общей стоимости перевозки по варианту",
+        default=None,
+    )
+    show_baseclass: Optional[bool] = Field(
+        description="Добавлять к каждому подклассу код его базового класса",
+        default=None,
+    )
+    show_reg_latin: Optional[bool] = Field(
+        description="Указывать необходимость оформления билета на латинице",
+        default=None,
+    )
+    show_upt_rec: Optional[bool] = Field(description="Выдать детализацию УПТ", default=None)
+    show_fareexpdate: Optional[bool] = Field(
+        description="Указывать дату истечения срока действия тарифа",
+        default=None,
+    )
+    show_n_blanks: Optional[bool] = Field(
+        description="Возвращать количество билетов, необходимых для оформления перевозки",
+        default=None,
+    )
+    regroup: Optional[bool] = Field(description="Перегруппировка ответа", default=None)
+    split_companies: Optional[bool] = Field(
+        description="При перегруппировке ответа объединять в один вариант только рейсы одной "
+        "авиакомпании. Автоматически установит параметр запроса mix_ac='false'",
+        default=None,
+    )
+    reference_style_codes: Optional[bool] = Field(
+        description="Возвращать коды авиакомпаний по правилам, принятым в справочных запросах. "
+        "По доке default=true на стороне шлюза",
+        default=None,
+    )
+    mark_cityport: Optional[bool] = Field(
+        description="Добавлять в ответ признаки city или airport для пунктов",
+        default=None,
+    )
+    show_tml: Optional[bool] = Field(
+        description="Добавлять в ответ информацию о ТЛ на оформление перевозки",
+        default=None,
+    )
+    show_brand_info: Optional[bool] = Field(
+        description="Добавлять в ответ информацию о составе брендов",
+        default=None,
+    )
+    show_cat18: Optional[bool] = Field(
+        description="Добавлять в ответ примечания из кат. 18 УПТ",
+        default=None,
+    )
+    show_joint_id: Optional[bool] = Field(
+        description="Добавлять в ответ информацию о joint_id на сегментах перевозки",
+        default=None,
+    )
+    show_meals: Optional[bool] = Field(
+        description="Добавлять в ответ информацию о компоновке кабин и питании, включённом в билет",
+        default=None,
+    )
+    show_bag_norm_full: Optional[bool] = Field(
+        description="Добавлять в ответ детальную информацию о нормах бесплатного провоза "
+        "багажа и ручной клади",
+        default=None,
+    )
+
+    _nested: bool = True
+
+    def build(self) -> dict:
+        return {
+            **super().build(),
+            "show_available": self.show_available,
+            "show_io_matching": self.show_io_matching,
+            "show_flighttime": self.show_flighttime,
+            "show_varianttotal": self.show_varianttotal,
+            "show_baseclass": self.show_baseclass,
+            "show_reg_latin": self.show_reg_latin,
+            "show_upt_rec": self.show_upt_rec,
+            "show_fareexpdate": self.show_fareexpdate,
+            "show_n_blanks": self.show_n_blanks,
+            "regroup": self.regroup,
+            "split_companies": self.split_companies,
+            "reference_style_codes": self.reference_style_codes,
+            "mark_cityport": self.mark_cityport,
+            "show_tml": self.show_tml,
+            "show_brand_info": self.show_brand_info,
+            "show_cat18": self.show_cat18,
+            "show_joint_id": self.show_joint_id,
+            "show_meals": self.show_meals,
+            "show_bag_norm_full": self.show_bag_norm_full,
+        }

--- a/utair/clients/external/sirena/requests/pricing_common.py
+++ b/utair/clients/external/sirena/requests/pricing_common.py
@@ -72,9 +72,7 @@ class PricingFormPay(RequestModelABC):
 
 
 class PricingRequestParams(BaseRequestParams):
-    """
-    Специфичные параметры <request_params> для pricing-запросов
-    """
+    """Специфичные параметры <request_params> для pricing-запросов (Table 2.34)."""
 
     min_results: Optional[Union[int, Literal["spOnePass"]]] = Field(
         description="Минимальное желаемое количество разных оценок "
@@ -126,7 +124,7 @@ class PricingRequestParams(BaseRequestParams):
         description="Показывать только 'багажные' тарифы",
         default=None,
     )
-    # далее идут недокументированные параметры:
+    # Недокументировано в wiki (Table 2.34): et_if_possible, allow_change_of_airport, real_seats
     et_if_possible: Optional[bool] = Field(
         description="Оформление ЭБ при возможности",
         default=False,
@@ -139,7 +137,6 @@ class PricingRequestParams(BaseRequestParams):
         description="Учитывать реальное количество мест",
         default=None,
     )
-    # --------------------------------
 
     _nested: bool = True
 
@@ -187,9 +184,7 @@ class PricingRequestParams(BaseRequestParams):
 
 
 class PricingAnswerParams(BaseAnswerParams):
-    """
-    Специфичные параметры <answer_params> для pricing-запросов
-    """
+    """Специфичные параметры <answer_params> для pricing-запросов (Table 2.35)."""
 
     show_available: Optional[bool] = Field(
         description="Добавлять в ответ информацию о наличии мест на подклассе",
@@ -264,6 +259,19 @@ class PricingAnswerParams(BaseAnswerParams):
         "багажа и ручной клади",
         default=None,
     )
+    # Недокументировано в wiki (Table 2.35): show_et, show_regroup_io_matching, show_trcantpr
+    show_et: Optional[bool] = Field(
+        description="Признак доступности оформления ЭБ на рейсе",
+        default=None,
+    )
+    show_regroup_io_matching: Optional[bool] = Field(
+        description="Соответствие сегментов при regroup",
+        default=None,
+    )
+    show_trcantpr: Optional[bool] = Field(
+        description="Детализация тарифа",
+        default=None,
+    )
 
     _nested: bool = True
 
@@ -289,4 +297,7 @@ class PricingAnswerParams(BaseAnswerParams):
             "show_joint_id": self.show_joint_id,
             "show_meals": self.show_meals,
             "show_bag_norm_full": self.show_bag_norm_full,
+            "show_et": self.show_et,
+            "show_regroup_io_matching": self.show_regroup_io_matching,
+            "show_trcantpr": self.show_trcantpr,
         }


### PR DESCRIPTION
**Что сделано:**
GetPricingRoute приведён к wiki: сегменты, PricingRoutePassenger, SSR, PricingRequestParams/PricingAnswerParams
Вынесены params_base.py и pricing_common.py; RequestParams/AnswerParams в common — re-export (monobrand без изменений)
Для корзины (UTBCKN-5069): brands → request_params.brand
Для Search: show_et, show_regroup_io_matching, show_trcantpr в PricingAnswerParams

**Breaking:** только GetPricingRoute — PricingRoutePassenger вместо common.Passenger, List[SSRForAdd] вместо dict в special_services.