### PR TITLE
Feat/add ff info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sirena-client"
-version = "0.1.20-alpha"
+version = "0.1.21-alpha"
 description = "SirenaGDS Python Client"
 authors = ["Utair"]
 packages = [

--- a/utair/clients/external/sirena/requests/add_ff_info.py
+++ b/utair/clients/external/sirena/requests/add_ff_info.py
@@ -11,10 +11,12 @@ class PassengerForAddFFInfo(RequestModelABC):
     loyalty_card: str = Field(..., description="Номер карточки, идентифицирующей клиента")
     segments: List[str] = Field(default_factory=list, description="Идентификаторы сегментов")
 
+    _nested: bool = True
+
     def build(self) -> dict:
         return {
-            '@id': 'passenger_id',              # FIXME
-            'freq_flier_id': 'loyalty_card',    # FIXME
+            '@id': self.passenger_id,
+            'freq_flier_id': self.loyalty_card,
             'segment': [
                 {'@id': s} for s in self.segments
             ]


### PR DESCRIPTION
PassengerForAddFFInfo.build() эмитил литеральные строки 'passenger_id'/
'loyalty_card' вместо значений полей (FIXME) -- каждый запрос add_ff_info
уходил в Sirena битым. Тело приведено к рабочему формату legacy-клиента
(sirena_xml_client): @id/freq_flier_id -- значения, segment -- [{@id: ...}].
Добавлен _nested по конвенции вложенных моделей (SSRForAdd и др.).
